### PR TITLE
Implementation of Message for SMS

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    compile project(path: ':smslibrary')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    compile project(path: ':smslibrary')
+    implementation project(path: ':smslibrary')
 }

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSMessage.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSMessage.java
@@ -1,5 +1,7 @@
 package com.eis.smslibrary;
 
+import androidx.annotation.NonNull;
+
 import com.eis.communication.Message;
 import com.eis.smslibrary.exceptions.InvalidSMSMessageException;
 
@@ -23,10 +25,10 @@ public class SMSMessage implements Message<String, SMSPeer> {
      * Constructor for a sms text message.
      *
      * @param peer        a valid peer
-     * @param messageText the message content
+     * @param messageText the message content, can be empty but not null
      * @throws InvalidSMSMessageException if checkMessageText is different from MESSAGE_TEXT_VALID
      */
-    public SMSMessage(SMSPeer peer, String messageText) throws InvalidSMSMessageException {
+    public SMSMessage(@NonNull SMSPeer peer, @NonNull String messageText) throws InvalidSMSMessageException {
         //Checks on the message text
         ContentState contentState = checkMessageText(messageText);
         if (contentState != ContentState.MESSAGE_TEXT_VALID)
@@ -41,7 +43,7 @@ public class SMSMessage implements Message<String, SMSPeer> {
      * @param messageText to be checked.
      * @return The state of the message after the validity tests.
      */
-    public static ContentState checkMessageText(String messageText) {
+    public static ContentState checkMessageText(@NonNull String messageText) {
         if (messageText.length() > SMSMessage.MAX_MSG_TEXT_LEN) {
             return ContentState.MESSAGE_TEXT_TOO_LONG;
         }

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSMessage.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSMessage.java
@@ -1,0 +1,101 @@
+package com.eis.smslibrary;
+
+import com.eis.communication.Message;
+import com.eis.smslibrary.exceptions.InvalidSMSMessageException;
+
+/**
+ * Representation of a single sms message
+ * This class does NOT parse SMSMessages into sms-ready strings and back!
+ *
+ * @author Luca Crema, Marco Mariotto, Alberto Ursino
+ */
+public class SMSMessage implements Message<String, SMSPeer> {
+
+    /**
+     * Kind of a magic number, should be around 160 but doesn't work all the times.
+     * (suggestions accepted)
+     */
+    public static final int MAX_MSG_TEXT_LEN = 155;
+    private String messageContent;
+    private SMSPeer peer;
+
+    /**
+     * Constructor for a sms text message.
+     *
+     * @param peer        a valid peer
+     * @param messageText the message content
+     * @throws InvalidSMSMessageException if checkMessageText is different from MESSAGE_TEXT_VALID
+     */
+    public SMSMessage(SMSPeer peer, String messageText) throws InvalidSMSMessageException {
+        //Checks on the message text
+        ContentState contentState = checkMessageText(messageText);
+        if (contentState != ContentState.MESSAGE_TEXT_VALID)
+            throw new InvalidSMSMessageException("Message text length exceeds maximum allowed", contentState);
+        this.messageContent = messageText;
+        this.peer = peer;
+    }
+
+    /**
+     * Checks if the message content could be valid.
+     *
+     * @param messageText to be checked.
+     * @return The state of the message after the validity tests.
+     */
+    public static ContentState checkMessageText(String messageText) {
+        if (messageText.length() > SMSMessage.MAX_MSG_TEXT_LEN) {
+            return ContentState.MESSAGE_TEXT_TOO_LONG;
+        }
+        return ContentState.MESSAGE_TEXT_VALID;
+    }
+
+    /**
+     * Retrieves the data received by or to be sent in the network.
+     *
+     * @return data contained in this message or to put in an sms
+     */
+    @Override
+    public String getData() {
+        return messageContent;
+    }
+
+    /**
+     * Retrieves the sender or the destination for the message
+     *
+     * @return Peer associated with this message
+     */
+    @Override
+    public SMSPeer getPeer() {
+        return peer;
+    }
+
+    /**
+     * Possible states of a message after a check
+     * There could be more in future so it has been used an enum
+     * <p>
+     * These are used in {@link #checkMessageText}
+     */
+    public enum ContentState {
+        MESSAGE_TEXT_VALID,
+        MESSAGE_TEXT_TOO_LONG
+    }
+
+    /**
+     * Possible states of a message after it has been sent
+     * These are given by Android library as an int, they have been put in an enum
+     * so that one can see all the possible values without having to
+     * look at the official Android documentation
+     * <p>
+     * These are used in {@link SMSMessageSentListener}
+     */
+    public enum SentState {
+        MESSAGE_SENT,
+        ERROR_GENERIC_FAILURE,
+        ERROR_RADIO_OFF,
+        ERROR_NULL_PDU,
+        ERROR_NO_SERVICE,
+        ERROR_LIMIT_EXCEEDED
+    }
+}
+
+
+

--- a/smslibrary/src/main/java/com/eis/smslibrary/exceptions/InvalidSMSMessageException.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/exceptions/InvalidSMSMessageException.java
@@ -1,0 +1,47 @@
+package com.eis.smslibrary.exceptions;
+
+import com.eis.smslibrary.SMSMessage;
+
+/**
+ * Thrown when user tries to work on a SMSMessage with an invalid content
+ * @author Luca Crema
+ */
+public class InvalidSMSMessageException extends RuntimeException {
+
+    /**
+     * Invalid state of a message content
+     */
+    private SMSMessage.ContentState state;
+
+    /**
+     *
+     * @param message exception message content
+     * @param state invalid message content state
+     */
+    public InvalidSMSMessageException(String message, SMSMessage.ContentState state) {
+        super(message);
+        if(state == SMSMessage.ContentState.MESSAGE_TEXT_VALID)
+            throw new IllegalArgumentException("Cannot throw exception on valid message content state");
+        this.state = state;
+    }
+
+    /**
+     *
+     * @param cause exception cause
+     * @param state invalid message content state
+     */
+    public InvalidSMSMessageException(Throwable cause, SMSMessage.ContentState state) {
+        super(cause);
+        if(state == SMSMessage.ContentState.MESSAGE_TEXT_VALID)
+            throw new IllegalArgumentException("Cannot throw exception on valid message content state");
+        this.state = state;
+    }
+
+    /**
+     * Retrieves the state of the message that is the reason of the exception
+     * @return
+     */
+    public SMSMessage.ContentState getState() {
+        return this.state;
+    }
+}

--- a/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageTest.java
+++ b/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageTest.java
@@ -24,7 +24,7 @@ public class SMSMessageTest{
 
     @Before
     public void init() {
-        smsMessage = new SMSMessage(new SMSPeer(VALID_TELEPHONE_NUMBER), VALID_TEXT_MESSAGE);
+        new SMSMessage(new SMSPeer(VALID_TELEPHONE_NUMBER), VALID_TEXT_MESSAGE);
     }
 
     @Test(expected = InvalidSMSMessageException.class)

--- a/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageTest.java
+++ b/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageTest.java
@@ -1,0 +1,70 @@
+package com.eis.smslibrary;
+
+import com.eis.smslibrary.exceptions.InvalidSMSMessageException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Alberto Ursino, Luca Crema
+ */
+public class SMSMessageTest{
+
+    private SMSMessage smsMessage;
+    private static final int MAX_MSG_TEXT_LEN = SMSMessage.MAX_MSG_TEXT_LEN;
+    private static final String MAIN_MESSAGE = "Test message";
+    private static final String VALID_TEXT_MESSAGE = MAIN_MESSAGE;
+    private static final String TOO_LONG_TEXT_MESSAGE = new String(new char[MAX_MSG_TEXT_LEN * 2]).replace('\0', ' ');
+    private static final String MAX_LENGTH_TEXT_MESSAGE = new String(new char[MAX_MSG_TEXT_LEN]).replace('\0', ' ');
+    private static final String MAX_LENGTH_TEXT_MESSAGE_P1 = new String(new char[MAX_MSG_TEXT_LEN + 1]).replace('\0', ' '); //P1 = Plus 1
+    private static final String EMPTY_TEXT_MESSAGE = "";
+    private static final String VALID_TELEPHONE_NUMBER = "+393433433433";
+
+
+    @Before
+    public void init() {
+        smsMessage = new SMSMessage(new SMSPeer(VALID_TELEPHONE_NUMBER), VALID_TEXT_MESSAGE);
+    }
+
+    @Test(expected = InvalidSMSMessageException.class)
+    public void smsMessage_constructor_notValidTextMessage() {
+        smsMessage = new SMSMessage(new SMSPeer(VALID_TELEPHONE_NUMBER), TOO_LONG_TEXT_MESSAGE);
+        Assert.fail("Should have thrown an InvalidSMSMessageException");
+    }
+
+    @Test
+    public void checkMessageText_smsText_isTooLong() {
+        Assert.assertEquals(SMSMessage.ContentState.MESSAGE_TEXT_TOO_LONG, SMSMessage.checkMessageText(TOO_LONG_TEXT_MESSAGE));
+    }
+
+    @Test
+    public void checkMessageText_smsText_isTooLongByOne() {
+        Assert.assertEquals(SMSMessage.ContentState.MESSAGE_TEXT_TOO_LONG, SMSMessage.checkMessageText(MAX_LENGTH_TEXT_MESSAGE_P1));
+    }
+
+    @Test
+    public void checkMessageText_smsText_isMaxLength() {
+        Assert.assertEquals(SMSMessage.ContentState.MESSAGE_TEXT_VALID, SMSMessage.checkMessageText(MAX_LENGTH_TEXT_MESSAGE));
+    }
+
+    @Test
+    public void checkMessageText_smsText_isValid() {
+        Assert.assertEquals(SMSMessage.ContentState.MESSAGE_TEXT_VALID, SMSMessage.checkMessageText(VALID_TEXT_MESSAGE));
+    }
+
+    @Test
+    public void checkMessageText_smsText_isEmpty() {
+        Assert.assertEquals(SMSMessage.ContentState.MESSAGE_TEXT_VALID, SMSMessage.checkMessageText(EMPTY_TEXT_MESSAGE));
+    }
+
+    @Test
+    public void getPeer_smsPeer_isEquals() {
+        Assert.assertEquals(VALID_TELEPHONE_NUMBER, smsMessage.getPeer().toString());
+    }
+
+    @Test
+    public void getData_smsData_isEquals() {
+        Assert.assertEquals(VALID_TEXT_MESSAGE, smsMessage.getData());
+    }
+}


### PR DESCRIPTION
This is (part of) the implementation of the SMSMessage for group 4.

The build.gradle was changed for the application to have access to the library.

SMSMessage is just a representation of a sent or received message, and its main purpose is to validity-check the message content for new messages that have to be sent.
`IllegalSMSMessageContentException` is an exception thrown in case of a new message is instantiated without having message content checked.
`SMSMessage.SentState` is an `enum` of states that can be assumed by the message when is being sent: after a long discussion we came to the conclusion that this state is not always part of the message so it should not be saved inside a variable, instead it will be passed as a parameter on the `SMSMessageSentListener.onMessageSent(...)` that is the only place a user would want to use this state information.

Tests cover most of the file, except for SentState enum that, as mentioned before, is not used already.

The parsing of this message class to a String that can be put in a SMS or from a String to a SMSMessage is **not** done in this class: there will be a SMSMessageHandler for that kind of things.