### PR TITLE
SMS implementation of Message Handler and MessageParserStrategy

### DIFF
--- a/smslibrary/src/main/java/com/eis/communication/MessageHandler.java
+++ b/smslibrary/src/main/java/com/eis/communication/MessageHandler.java
@@ -22,7 +22,7 @@ public interface MessageHandler<D,P,M extends Message> {
     /**
      * Translates a message into data that can be sent via communication channel
      *
-     * @param message message to be translated
+     * @param message to be translated
      * @return the data to send
      */
     D parseData (M message);

--- a/smslibrary/src/main/java/com/eis/communication/MessageHandler.java
+++ b/smslibrary/src/main/java/com/eis/communication/MessageHandler.java
@@ -4,23 +4,26 @@ package com.eis.communication;
  * Class used to switch from actual communication data to Message and back
  * Should use a <a href='https://en.wikipedia.org/wiki/Singleton_pattern'>Singleton pattern</a>
  *
+ * @param <D> The data type used by the channel
+ * @param <P> The peer type used by the channel
  * @param <M> The type of message to parse and output
  */
-public interface MessageHandler<M extends Message> {
+public interface MessageHandler<D,P,M extends Message> {
 
     /**
-     * Interprets a string arrived via the communication channel and parses it to a message
+     * Interprets data arrived via the communication channel and parses it to a message
      *
-     * @param data data from the communication channel
-     * @return the message if the string has been parsed correctly, null otherwise
+     * @param peerData from the communication channel
+     * @param data from the communication channel
+     * @return the message if the data has been parsed correctly, null otherwise
      */
-    M parseMessage(String data, String peerData);
+    M parseMessage(P peerData, D data);
 
     /**
-     * Translates a message into a string that can be sent via communication channel
+     * Translates a message into data that can be sent via communication channel
      *
      * @param message message to be translated
-     * @return the string to send
+     * @return the data to send
      */
-    String getOutput(M message);
+    D parseData (M message);
 }

--- a/smslibrary/src/main/java/com/eis/communication/MessageParseStrategy.java
+++ b/smslibrary/src/main/java/com/eis/communication/MessageParseStrategy.java
@@ -1,0 +1,31 @@
+package com.eis.communication;
+
+/**
+ * This is a <a href="https://refactoring.guru/design-patterns/strategy">strategy pattern</a>:
+ * every implementation of MessageHandler can use different strategies based on what the user wants to do
+ *
+ * @param <D> The data type used by the channel
+ * @param <P> The peer type used by the channel
+ * @param <M> The type of message to parse and output
+ * @author Luca Crema (thanks to Marco Cognolato for design pattern reference)
+ */
+public interface MessageParseStrategy<D, P extends Peer, M extends Message> {
+
+    /**
+     * Parse channel data into a library message
+     *
+     * @param channelData read from the channel
+     * @param channelPeer the sender of the channel message
+     * @return library message
+     */
+    M parseMessage(D channelData, P channelPeer);
+
+    /**
+     * Parse library message into channel data
+     *
+     * @param message from library
+     * @return channel data
+     */
+    D parseData(M message);
+
+}

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSMessageHandler.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSMessageHandler.java
@@ -35,7 +35,7 @@ public class SMSMessageHandler implements MessageHandler<String, String, SMSMess
 
     /**
      * Update the parse strategy to a custom one
-     * @param parseStrategy ?
+     * @param parseStrategy custom message parsing
      */
     public void setMessageParseStrategy(@NonNull final MessageParseStrategy<String,SMSPeer,SMSMessage> parseStrategy){
         this.parseStrategy = parseStrategy;

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSMessageHandler.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSMessageHandler.java
@@ -1,0 +1,94 @@
+package com.eis.smslibrary;
+
+import com.eis.communication.MessageParseStrategy;
+
+/**
+ * Singleton class used to parse String to SMSMessage and back
+ * Uses a strategy to parse messages, so that any user can update it to its preferred parser
+ * By defaults it uses a default strategy, defined by the library
+ *
+ * @author Luca Crema, Alberto Ursino, Marco Mariotto
+ */
+public class SMSMessageHandler implements MessageHandler<String, String, SMSMessage> {
+
+    private MessageParseStrategy<String, SMSPeer, SMSMessage> parseStrategy;
+    private static SMSMessageHandler instance;
+
+    /**
+     * Private constructor
+     */
+    private SMSMessageHandler(){
+        parseStrategy = new DefaultSMSMessageParseStrategy();
+    }
+
+    /**
+     * @return Singleton instance of this class
+     */
+    public static SMSMessageHandler getInstance(){
+        if(instance == null)
+            instance = new SMSMessageHandler();
+        return instance;
+    }
+
+    /**
+     * Update the parse strategy to a custom one
+     * @param parseStrategy ?
+     */
+    public void setMessageParseStrategy(MessageParseStrategy<String,SMSPeer,SMSMessage> parseStrategy){
+        this.parseStrategy = parseStrategy;
+    }
+
+    /**
+     * Interprets a string arrived via the communication channel and parses it to a library {@link SMSMessage}
+     *
+     * @param peerData from the sms pdus
+     * @param messageData from the sms pdus
+     * @return the message if the string has been parsed correctly, null otherwise
+     */
+    public SMSMessage parseMessage(String peerData, String messageData){
+        if(SMSPeer.checkPhoneNumber(peerData) != SMSPeer.TelephoneNumberState.TELEPHONE_NUMBER_VALID)
+            return null;
+
+        return parseStrategy.parseMessage(messageData,new SMSPeer(peerData));
+    }
+
+    /**
+     * Translates a message into a string that can be sent via sms
+     *
+     * @param message message to be translated/parsed
+     * @return the string to send
+     */
+    public String parseData(SMSMessage message){
+        return parseStrategy.parseData(message);
+    }
+
+}
+
+class DefaultSMSMessageParseStrategy implements MessageParseStrategy<String, SMSPeer, SMSMessage>{
+
+    protected static final String HIDDEN_CHARACTER = (char) 0x02 + "";
+
+    /**
+     * Parses sms data into a SMSMessage if possible
+     * @param channelData read from the channel
+     * @return the parsed SMSMessage if the string was correct, null otherwise
+     */
+    @Override
+    public SMSMessage parseMessage(String channelData, SMSPeer channelPeer) {
+        //First character of the content must be the hidden char
+        if (!channelData.startsWith(HIDDEN_CHARACTER))
+            return null;
+
+        return new SMSMessage(channelPeer, channelData);
+    }
+
+    /**
+     * Parses SMSMessage into sms content data
+     * @param message from library
+     * @return the parsed sms content data ready to be sent
+     */
+    @Override
+    public String parseData(SMSMessage message) {
+        return HIDDEN_CHARACTER + message.getData();
+    }
+}

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSMessageHandler.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSMessageHandler.java
@@ -58,7 +58,7 @@ public class SMSMessageHandler implements MessageHandler<String, String, SMSMess
     /**
      * Translates a message into a string that can be sent via sms
      *
-     * @param message message to be translated/parsed
+     * @param message to be translated/parsed
      * @return the string to send
      */
     public String parseData(@NonNull final SMSMessage message){
@@ -72,6 +72,7 @@ public class SMSMessageHandler implements MessageHandler<String, String, SMSMess
         /**
          * Parses sms data into a SMSMessage if possible
          * @param channelData read from the channel
+         * @param channelPeer that sent the data
          * @return the parsed SMSMessage if the string was correct, null otherwise
          */
         @Override
@@ -79,8 +80,8 @@ public class SMSMessageHandler implements MessageHandler<String, String, SMSMess
             //First character of the content must be the hidden char
             if (!channelData.startsWith(HIDDEN_CHARACTER))
                 return null;
-            String actualMessageData = channelData.substring(1);
-            return new SMSMessage(channelPeer, actualMessageData);
+            String messageData = channelData.substring(1);
+            return new SMSMessage(channelPeer, messageData);
         }
 
         /**

--- a/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageHandlerTest.java
+++ b/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageHandlerTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
  */
 public class SMSMessageHandlerTest {
 
-    SMSMessageHandler defaultInstance;
+    private SMSMessageHandler defaultInstance;
     private static final MessageParseStrategy<String,SMSPeer,SMSMessage> DEFAULT_SMS_MESSAGE_PARSE_STRATEGY = SMSMessageHandler.getInstance().new DefaultSMSMessageParseStrategy();
     private static final SMSPeer DEFAULT_PEER = new SMSPeer("+393465433432");
     private static final String DEFAULT_MESSAGE_CONTENT = "Test content";
@@ -40,7 +40,6 @@ public class SMSMessageHandlerTest {
      */
     @Test
     public void parseMessage_wrongSMS_isNull(){
-
         Assert.assertNull(defaultInstance.parseMessage(DEFAULT_PEER.getAddress(),DEFAULT_MESSAGE_CONTENT));
     }
 }

--- a/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageHandlerTest.java
+++ b/smslibrary/src/test/java/com/eis/smslibrary/SMSMessageHandlerTest.java
@@ -1,0 +1,46 @@
+package com.eis.smslibrary;
+
+import com.eis.communication.MessageParseStrategy;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Luca Crema
+ */
+public class SMSMessageHandlerTest {
+
+    SMSMessageHandler defaultInstance;
+    private static final MessageParseStrategy<String,SMSPeer,SMSMessage> DEFAULT_SMS_MESSAGE_PARSE_STRATEGY = SMSMessageHandler.getInstance().new DefaultSMSMessageParseStrategy();
+    private static final SMSPeer DEFAULT_PEER = new SMSPeer("+393465433432");
+    private static final String DEFAULT_MESSAGE_CONTENT = "Test content";
+    private static final SMSMessage DEFAULT_MESSAGE = new SMSMessage(DEFAULT_PEER,DEFAULT_MESSAGE_CONTENT);
+
+    @Before
+    public void init(){
+        defaultInstance = SMSMessageHandler.getInstance();
+
+        defaultInstance.setMessageParseStrategy(DEFAULT_SMS_MESSAGE_PARSE_STRATEGY);
+    }
+
+    @Test
+    public void getInstance_isNotNull() {
+        Assert.assertNotNull(SMSMessageHandler.getInstance());
+    }
+
+
+    @Test
+    public void parseMessage_message_isCorrect() {
+        Assert.assertEquals(DEFAULT_MESSAGE.getData(),defaultInstance.parseMessage(DEFAULT_PEER.getAddress(), defaultInstance.parseData(DEFAULT_MESSAGE)).getData());
+    }
+
+    /**
+     * If a normal sms is parsed (without hidden character) it should return null
+     */
+    @Test
+    public void parseMessage_wrongSMS_isNull(){
+
+        Assert.assertNull(defaultInstance.parseMessage(DEFAULT_PEER.getAddress(),DEFAULT_MESSAGE_CONTENT));
+    }
+}


### PR DESCRIPTION
You're going to like this one: this class has two easy methods to parse messages to SMS and back BUT the way that does it is defined inside another class that can be overwritten so that one can have its own personal message parsing if he needs to.
Default parser uses a hidden character as suggested by group 0 implementation to avoid parsing normal SMS.
Also, I had to generalize MessageHandler parameters because it's not true that all channel use String, it could be byte array or whatever.
Hope that [@mattia-fanan](https://github.com/MattiaFanan-uni) enjoys all the @NonNull annotations and final in parameters.

Reference for Singleton: https://refactoring.guru/design-patterns/singleton
Reference for Strategy: https://refactoring.guru/design-patterns/strategy

Tests cover 100% of the SMSMessageHandler class when it's using default parser.