### PR TITLE
Fix for JobIntentService not starting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".ReceivedMessageListener"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/smslibproject/MainActivity.java
+++ b/app/src/main/java/com/example/smslibproject/MainActivity.java
@@ -1,5 +1,8 @@
 package com.example.smslibproject;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
@@ -10,6 +13,7 @@ import com.eis.smslibrary.SMSPeer;
 import com.eis.smslibrary.listeners.SMSSentListener;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -17,6 +21,13 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (checkSelfPermission(Manifest.permission.SEND_SMS) != PackageManager.PERMISSION_GRANTED && checkSelfPermission(Manifest.permission.RECEIVE_SMS) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.SEND_SMS, Manifest.permission.RECEIVE_SMS}, 1);
+            }
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.SEND_SMS, Manifest.permission.RECEIVE_SMS}, 1);
+        }
 
         SMSManager.getInstance().setReceivedListener(ReceivedMessageListener.class, this);
 

--- a/app/src/main/java/com/example/smslibproject/MainActivity.java
+++ b/app/src/main/java/com/example/smslibproject/MainActivity.java
@@ -1,8 +1,15 @@
 package com.example.smslibproject;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+
+import com.eis.smslibrary.SMSManager;
+import com.eis.smslibrary.SMSMessage;
+import com.eis.smslibrary.SMSPeer;
+import com.eis.smslibrary.listeners.SMSSentListener;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -10,5 +17,26 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        SMSManager.getInstance().setReceivedListener(ReceivedMessageListener.class, this);
+
+        findViewById(R.id.button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onSendMessage();
+            }
+        });
+
     }
+
+    public void onSendMessage() {
+        SMSManager.getInstance().sendMessage(new SMSMessage(new SMSPeer("+393467965447"), "Heya"), new SMSSentListener() {
+            @Override
+            public void onSMSSent(SMSMessage message, SMSMessage.SentState sentState) {
+                Toast.makeText(MainActivity.this, "Inviato", Toast.LENGTH_LONG).show();
+            }
+        }, this);
+    }
+
+
 }

--- a/app/src/main/java/com/example/smslibproject/ReceivedMessageListener.java
+++ b/app/src/main/java/com/example/smslibproject/ReceivedMessageListener.java
@@ -1,0 +1,13 @@
+package com.example.smslibproject;
+
+import android.util.Log;
+
+import com.eis.smslibrary.SMSMessage;
+import com.eis.smslibrary.listeners.SMSReceivedServiceListener;
+
+public class ReceivedMessageListener extends SMSReceivedServiceListener {
+    @Override
+    public void onMessageReceived(SMSMessage message) {
+        Log.e("RML", "Received a message: " + message.getData());
+    }
+}

--- a/app/src/main/java/com/example/smslibproject/ReceivedMessageListener.java
+++ b/app/src/main/java/com/example/smslibproject/ReceivedMessageListener.java
@@ -8,6 +8,6 @@ import com.eis.smslibrary.listeners.SMSReceivedServiceListener;
 public class ReceivedMessageListener extends SMSReceivedServiceListener {
     @Override
     public void onMessageReceived(SMSMessage message) {
-        Log.e("RML", "Received a message: " + message.getData());
+        Log.i("RML", "Received a message: " + message.getData());
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,9 +19,11 @@
         android:id="@+id/button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginLeft="32dp"
         android:layout_marginTop="44dp"
         android:text="Send message"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:layout_editor_absoluteX="142dp" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,4 +15,13 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="44dp"
+        android:text="Send message"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_editor_absoluteX="142dp" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSManager.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSManager.java
@@ -171,7 +171,7 @@ public class SMSManager implements CommunicationManager<SMSMessage> {
      * @param context                   the context used to set the listener
      */
     public <T extends SMSReceivedServiceListener> void setReceivedListener(Class<T> receivedListenerClassName, Context context) {
-        PreferencesManager.setString(context, SMSReceivedBroadcastReceiver.SERVICE_CLASS_PREFERENCES_KEY, receivedListenerClassName.toString());
+        PreferencesManager.setString(context, SMSReceivedBroadcastReceiver.SERVICE_CLASS_PREFERENCES_KEY, receivedListenerClassName.getName());
     }
 
     /**

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSReceivedBroadcastReceiver.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSReceivedBroadcastReceiver.java
@@ -74,10 +74,11 @@ public class SMSReceivedBroadcastReceiver extends BroadcastReceiver {
      */
     private void callApplicationService(Context context, SMSMessage message) {
         Class<?> listener = null;
+        String preferencesClassName = PreferencesManager.getString(context, SERVICE_CLASS_PREFERENCES_KEY);
         try {
-            listener = Class.forName(PreferencesManager.getString(context, SERVICE_CLASS_PREFERENCES_KEY));
+            listener = Class.forName(preferencesClassName);
         } catch (ClassNotFoundException e) {
-            Log.e("SMSReceiver", "Service class to wake up could not be found");
+            Log.e("SMSReceiver", "Service class to wake up could not be found: " + preferencesClassName);
         }
         if (listener == null)
             return;

--- a/smslibrary/src/main/java/com/eis/smslibrary/listeners/SMSReceivedServiceListener.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/listeners/SMSReceivedServiceListener.java
@@ -1,12 +1,13 @@
 package com.eis.smslibrary.listeners;
 
 import android.content.Intent;
-
-import androidx.annotation.Nullable;
-import androidx.core.app.JobIntentService;
+import android.util.Log;
 
 import com.eis.smslibrary.SMSMessage;
 import com.eis.smslibrary.SMSReceivedBroadcastReceiver;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.JobIntentService;
 
 /**
  * Abstract class to implement in order to wake up the service when a message is received
@@ -30,6 +31,7 @@ public abstract class SMSReceivedServiceListener extends JobIntentService {
      */
     @Override
     protected void onHandleWork(@Nullable Intent intent) {
+        Log.i("SMSRSL", "Listener woke up");
         SMSMessage message = (SMSMessage) intent.getSerializableExtra(SMSReceivedBroadcastReceiver.INTENT_MESSAGE_TAG);
         onMessageReceived(message);
     }


### PR DESCRIPTION
## Premise
The `JobIntentService` kind of service requires a different way to start.

## Changes

### 1. Changed the way to start the service
I used the correct `JobIntentService.enqueueWork` method to start the service, now it works correctly, I tested.

### 2. Changed the way the service class name gets stored
We had a `ClassNotFoundException` when working with the library, might be because we were using `Class<?>.toString()` instead of `Class<?>.getName()`, I don't know so I added some debugging info to the exception message.

### 3. Updated README.md
It was kinda outdated, there was still `SMSHandler` and no explanation about how to register the message receiver service correctly.

___
Hope this gets accepted soon, we are working with this library and we need it to work properly.