### PR TITLE
Fixes/service not starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the single module `build.gradle` add:
 ```java
 dependencies {
     ...
-    implementation 'com.github.Cogno-IDU:smslibrary:v-1.0'
+    implementation 'com.github.Cogno-IDU:smslibrary:v2.1'
 }
 ```
 ## Usage
@@ -65,7 +65,7 @@ SMSManager.getInstance().sendMessage(msg, new SMSSentListener() {
 ```
 If you are planning to use SMS delivery reports, you can have a callback for those too:
 ```java
-SMSHandler.getInstance().sendMessage(msg, new SMSDeliveredListener() {
+SMSManager.getInstance().sendMessage(msg, new SMSDeliveredListener() {
     @Override
     public void onSMSDelivered(SMSMessage message, SMSMessage.DeliveredState deliveredState) {
         // Do something
@@ -79,8 +79,16 @@ In order to register the application to be called on message reception you have
  to register a custom listener service that extends `SMSReceivedServiceListener`.
  To do so you have to receive a class (not an instance):
  ```java
- SMSHandler.getInstance().setReceivedListener(MyCustomReceiver.class);
+ SMSManager.getInstance().setReceivedListener(MyCustomReceiver.class);
  ```
+ This service must be registered in the manifest inside the `<application>` tags like this:
+ ```java
+ <service
+            android:name=".MyCustomReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+```
  When a message arrives the overridden method `onMessageReceived` will be called.
  
 ### Using your own message format

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSManager.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSManager.java
@@ -5,14 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.eis.communication.CommunicationManager;
 import com.eis.smslibrary.listeners.SMSDeliveredListener;
 import com.eis.smslibrary.listeners.SMSReceivedServiceListener;
 import com.eis.smslibrary.listeners.SMSSentListener;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import it.lucacrema.preferences.PreferencesManager;
 
 /**
@@ -171,7 +170,7 @@ public class SMSManager implements CommunicationManager<SMSMessage> {
      * @param context                   the context used to set the listener
      */
     public <T extends SMSReceivedServiceListener> void setReceivedListener(Class<T> receivedListenerClassName, Context context) {
-        PreferencesManager.setString(context, SMSReceivedBroadcastReceiver.SERVICE_CLASS_PREFERENCES_KEY, receivedListenerClassName.toString());
+        PreferencesManager.setString(context, SMSReceivedBroadcastReceiver.SERVICE_CLASS_PREFERENCES_KEY, receivedListenerClassName.getName());
     }
 
     /**

--- a/smslibrary/src/main/java/com/eis/smslibrary/SMSReceivedBroadcastReceiver.java
+++ b/smslibrary/src/main/java/com/eis/smslibrary/SMSReceivedBroadcastReceiver.java
@@ -7,6 +7,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.telephony.SmsMessage;
 import android.util.Log;
+
+import androidx.core.app.JobIntentService;
 import it.lucacrema.preferences.PreferencesManager;
 
 /**
@@ -20,6 +22,7 @@ public class SMSReceivedBroadcastReceiver extends BroadcastReceiver {
 
     public static final String INTENT_MESSAGE_TAG = "SMSMessage";
     public static final String SERVICE_CLASS_PREFERENCES_KEY = "ApplicationServiceClass";
+    private static final int SCHEDULING_JOB_ID = 420;
 
     /**
      * Parses message and calls listener
@@ -74,17 +77,18 @@ public class SMSReceivedBroadcastReceiver extends BroadcastReceiver {
      */
     private void callApplicationService(Context context, SMSMessage message) {
         Class<?> listener = null;
+        String preferencesClassName = PreferencesManager.getString(context, SERVICE_CLASS_PREFERENCES_KEY);
         try {
-            listener = Class.forName(PreferencesManager.getString(context, SERVICE_CLASS_PREFERENCES_KEY));
+            listener = Class.forName(preferencesClassName);
         } catch (ClassNotFoundException e) {
-            Log.e("SMSReceiver", "Service class to wake up could not be found");
+            Log.e("SMSReceiver", "Service class to wake up could not be found: " + preferencesClassName);
         }
         if (listener == null)
             return;
 
-        Intent serviceIntent = new Intent(context, listener);
+        Intent serviceIntent = new Intent();
         serviceIntent.putExtra(INTENT_MESSAGE_TAG, message);
-        context.startService(serviceIntent);
+        JobIntentService.enqueueWork(context, listener, SCHEDULING_JOB_ID, serviceIntent);
 
     }
 }


### PR DESCRIPTION
## Premise
The `JobIntentService` kind of service requires a different way to start.

## Changes

### 1. Changed the way to start the service
I used the correct `JobIntentService.enqueueWork` method to start the service, now it works correctly, I tested.

### 2. Changed the way the service class name gets stored
We had a `ClassNotFoundException` when working with the library, might be because we were using `Class<?>.toString()` instead of `Class<?>.getName()`, I don't know so I added some debugging info to the exception message.

### 3. Updated README.md
It was kinda outdated, there was still `SMSHandler` and no explanation about how to register the message receiver service correctly.

___
Hope this gets accepted soon, we are working with this library and we need it to work properly.